### PR TITLE
fix conflicting black versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-black==21.12b0
+black==22.1.0
 mkdocs==1.2.3
 mkdocs-material==8.2.6
 mkdocs-simple-hooks==0.1.5


### PR DESCRIPTION
When trying to set it up locally I noticed that the version for black in `docs/requirements.txt` conflicted `tests\requirements-linting.txt`, making pip very angry.