### PR TITLE
Update docs for conda install

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ mamba install -c conda-forge watchfiles
 Binaries are available for:
 
 * **Linux**: `x86_64`
-* **MacOS**: `x86_64`
+* **MacOS**: `x86_64` & `arm64` (except python 3.7)
 * **Windows**: `amd64`
 
 ### From source


### PR DESCRIPTION
Since https://github.com/conda-forge/watchfiles-feedstock/pull/4 has been merged, the conda-forge installation now supports `arm64` on MacOS.