### PR TITLE
remove redundant `wheel` requirement from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'setuptools-rust']
+requires = ['setuptools', 'setuptools-rust']
 
 [tool.pytest.ini_options]
 testpaths = 'tests'


### PR DESCRIPTION
Remove the dependency on `wheel` from `pyproject.toml`.  It was never
required, and modern setuptools documentation advises against it.