### PR TITLE
Build manylinux2014 wheels for CentOS 7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
           CIBW_MANYLINUX_I686_IMAGE: manylinux_2_24
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-          CIBW_MUSLLINUX_X86_64_IMAGE: manylinux_2_24
+          CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
           CIBW_BEFORE_BUILD: rustup show
           CIBW_BEFORE_BUILD_LINUX: >
             curl https://sh.rustup.rs -sSf | sh -s -- --profile=minimal -y &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,8 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux_2_24
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_24
+          CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_1
           CIBW_BEFORE_BUILD: rustup show
           CIBW_BEFORE_BUILD_LINUX: >
             curl https://sh.rustup.rs -sSf | sh -s -- --profile=minimal -y &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,10 @@ jobs:
           CIBW_TEST_COMMAND: 'pytest {project}/tests -s'
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
-          CIBW_MANYLINUX_I686_IMAGE: manylinux_2_24
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_24
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_1
           CIBW_BEFORE_BUILD: rustup show
           CIBW_BEFORE_BUILD_LINUX: >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ pip install watchfiles
 ```
 
 Binaries are available for:
-* **Linux**: `x86_64`, `aarch64`, `i686` & `musl-aarch64`
+
+* **Linux**: `x86_64`, `aarch64`, `i686`, `musl-x86_64` & `musl-aarch64`
 * **MacOS**: `x86_64` & `arm64` (except python 3.7)
 * **Windows**: `amd64` & `win32`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ pip install watchfiles
 
 Binaries are available for:
 
-* **Linux**: `x86_64`, `aarch64`, `i686` & `musl-aarch64`
+* **Linux**: `x86_64`, `aarch64`, `i686`, `musl-x86_64` & `musl-aarch64`
 * **MacOS**: `x86_64` & `arm64` (except python 3.7)
 * **Windows**: `amd64` & `win32`
 


### PR DESCRIPTION
Fixes #130 

The environment now matches the default images for CIBW, but explicitly.

It also fixes the production of the x86_64 musllinux image, as noted in #130.

Change in list-pypi-files output:
```diff
--- 257747b7af919bdb283522b579abcd9d447d175a    2022-04-28 21:10:51.578092027 +1000
+++ c6431c5887360e2473560353ae978861297a4303    2022-04-28 21:10:51.588092922 +1000
@@ -1,34 +1,38 @@
 Run ls -lh dist/
-total 21M
+total 26M
 -rw-r--r-- 1 runner docker 302K watchfiles-0.0.dev0-cp310-cp310-macosx_10_9_x86_64.whl
 -rw-r--r-- 1 runner docker 293K watchfiles-0.0.dev0-cp310-cp310-macosx_11_0_arm64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp310-cp310-manylinux_2_24_i686.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp310-cp310-manylinux_2_24_x86_64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp310-cp310-musllinux_1_1_aarch64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp310-cp310-musllinux_1_1_x86_64.whl
 -rw-r--r-- 1 runner docker 197K watchfiles-0.0.dev0-cp310-cp310-win32.whl
 -rw-r--r-- 1 runner docker 204K watchfiles-0.0.dev0-cp310-cp310-win_amd64.whl
 -rw-r--r-- 1 runner docker 302K watchfiles-0.0.dev0-cp37-cp37m-macosx_10_9_x86_64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp37-cp37m-manylinux_2_24_i686.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp37-cp37m-manylinux_2_24_x86_64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp37-cp37m-musllinux_1_1_aarch64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp37-cp37m-musllinux_1_1_x86_64.whl
 -rw-r--r-- 1 runner docker 197K watchfiles-0.0.dev0-cp37-cp37m-win32.whl
 -rw-r--r-- 1 runner docker 204K watchfiles-0.0.dev0-cp37-cp37m-win_amd64.whl
 -rw-r--r-- 1 runner docker 302K watchfiles-0.0.dev0-cp38-cp38-macosx_10_9_x86_64.whl
 -rw-r--r-- 1 runner docker 292K watchfiles-0.0.dev0-cp38-cp38-macosx_11_0_arm64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp38-cp38-manylinux_2_24_i686.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp38-cp38-manylinux_2_24_x86_64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp38-cp38-musllinux_1_1_aarch64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp38-cp38-musllinux_1_1_x86_64.whl
 -rw-r--r-- 1 runner docker 197K watchfiles-0.0.dev0-cp38-cp38-win32.whl
 -rw-r--r-- 1 runner docker 204K watchfiles-0.0.dev0-cp38-cp38-win_amd64.whl
 -rw-r--r-- 1 runner docker 302K watchfiles-0.0.dev0-cp39-cp39-macosx_10_9_x86_64.whl
 -rw-r--r-- 1 runner docker 293K watchfiles-0.0.dev0-cp39-cp39-macosx_11_0_arm64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp39-cp39-manylinux_2_24_i686.whl
--rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp39-cp39-manylinux_2_24_x86_64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 -rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp39-cp39-musllinux_1_1_aarch64.whl
+-rw-r--r-- 1 runner docker 1.1M watchfiles-0.0.dev0-cp39-cp39-musllinux_1_1_x86_64.whl
 -rw-r--r-- 1 runner docker 198K watchfiles-0.0.dev0-cp39-cp39-win32.whl
 -rw-r--r-- 1 runner docker 205K watchfiles-0.0.dev0-cp39-cp39-win_amd64.whl
 -rw-r--r-- 1 runner docker  18K watchfiles-0.0.dev0.tar.gz
```

i.e. we gained `*-musllinux_1_1_x86_64.whl`, and replaced:
* `*-manylinux_2_24_i686.whl` => `*-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl`
* `*-manylinux_2_24_x86_64.whl` => `*-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`.