### PR TITLE
Suggestion: add one CLI usage example up-front

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ See [`arun_process` docs](https://watchfiles.helpmanual.io/api/run_process/#watc
 
 ## CLI
 
-**watchfiles** also comes with a CLI for running and reloading code.
+**watchfiles** also comes with a CLI for running and reloading code. To run `some command` when files in `src` change:
+
+```
+watchfiles "some command" src
+```
 
 For more information, see [the CLI docs](https://watchfiles.helpmanual.io/cli/).
 


### PR DESCRIPTION
`--help` is great but it's also good to show one valid example usage, especially for such a useful and practical tool. I think for the one usage example, it should show how to run a command (i.e. in quotes if it contains spaces), and that paths come second.