### PR TITLE
Build PyPy wheels for Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: test py${{ matrix.python-version }}, rust ${{ matrix.rust-version }} on ${{ matrix.os }}
+    name: test ${{ matrix.python-version }}, rust ${{ matrix.rust-version }} on ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +22,8 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11.0-alpha - 3.11'
+          - 'pypy3.8'
+          - 'pypy3.9'
 
     runs-on: ${{ matrix.os }}-latest
 
@@ -34,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: set up python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -81,7 +83,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
@@ -124,7 +126,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: set up python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
@@ -153,6 +155,10 @@ jobs:
         include:
           - os: ubuntu
             platform: linux
+            pypy: true
+          - os: macos
+            target: x86_64
+            pypy: true
           - os: windows
             ls: dir
           - os: windows
@@ -165,6 +171,7 @@ jobs:
           - os: ubuntu
             platform: linux
             target: armv7
+          # musllinux
           - os: ubuntu
             platform: linux
             target: x86_64
@@ -179,7 +186,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: set up python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           architecture: ${{ matrix.python-architecture || 'x64' }}
@@ -200,6 +207,14 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: --release --out dist
+
+      - name: build pypy wheels
+        if: ${{ matrix.pypy }}
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+          args: --release --out dist --interpreter pypy3.8 pypy3.9
 
       - run: ${{ matrix.ls || 'ls -lh' }} dist/
 
@@ -234,7 +249,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: set up python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['maturin>=0.12,<0.13']
+requires = ['maturin>=0.13,<0.14']
 build-backend = 'maturin'
 
 [project]


### PR DESCRIPTION
- Upgrade maturin to 0.13.0
- Build PyPy wheels for Linux and macOS

Build PyPy wheels for Windows is possible but it will need to install PyPy beforehand since you need to link to a dll or dll import library on Windows. I'll investigate that later to keep this one simpler.

PyPy 3.7 has [some tests timeout](https://github.com/messense/watchfiles/runs/7275540312?check_suite_focus=true) so I did not add it.