### PR TITLE
Add mypy, pytest cache to default exclude list

### DIFF
--- a/watchfiles/filters.py
+++ b/watchfiles/filters.py
@@ -82,6 +82,8 @@ class DefaultFilter(BaseFilter):
         'site-packages',
         '.idea',
         'node_modules',
+        '.mypy_cache',
+        '.pytest_cache',
     )
     """Directory names to ignore."""
 


### PR DESCRIPTION
mypy & pytest are fairly popular tools, so I'd like to propose adding their caches folder to the default exclude list.