### PR TITLE
Force polling on WSL

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,3 +179,25 @@ def time_taken(request):
         return TimeTaken(request.node.name, min_time, max_time)
 
     return time_taken
+
+
+class SetEnv:
+    def __init__(self):
+        self.envars = set()
+
+    def __call__(self, name, value):
+        self.envars.add(name)
+        os.environ[name] = value
+
+    def clear(self):
+        for n in self.envars:
+            os.environ.pop(n)
+
+
+@pytest.fixture
+def env():
+    setenv = SetEnv()
+
+    yield setenv
+
+    setenv.clear()

--- a/tests/test_force_polling.py
+++ b/tests/test_force_polling.py
@@ -1,0 +1,93 @@
+from __future__ import annotations as _annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from watchfiles import watch
+from watchfiles.main import _default_force_polling
+
+if TYPE_CHECKING:
+    from .conftest import SetEnv
+
+
+class MockRustNotify:
+    @staticmethod
+    def watch(*args):
+        return 'stop'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def test_watch_polling_not_env(mocker):
+    m = mocker.patch('watchfiles.main.RustNotify', return_value=MockRustNotify())
+
+    for _ in watch('.'):
+        pass
+
+    m.assert_called_once_with(['.'], False, False, 30, True)
+
+
+def test_watch_polling_env(mocker, env: SetEnv):
+    env('WATCHFILES_FORCE_POLLING', '1')
+    m = mocker.patch('watchfiles.main.RustNotify', return_value=MockRustNotify())
+
+    for _ in watch('.'):
+        pass
+
+    m.assert_called_once_with(['.'], False, True, 30, True)
+
+
+@pytest.mark.parametrize(
+    'env_var,arg,expected',
+    [
+        (None, True, True),
+        (None, False, False),
+        (None, None, False),
+        ('', True, True),
+        ('', False, False),
+        ('', None, False),
+        ('1', True, True),
+        ('1', False, False),
+        ('1', None, True),
+        ('disable', True, True),
+        ('disable', False, False),
+        ('disable', None, False),
+    ],
+)
+def test_default_force_polling(mocker, env: SetEnv, env_var, arg, expected):
+    uname = type('Uname', (), {'system': 'Linux', 'release': '1'})
+    mocker.patch('platform.uname', return_value=uname())
+    if env_var is not None:
+        env('WATCHFILES_FORCE_POLLING', env_var)
+    assert _default_force_polling(arg) == expected
+
+
+@pytest.mark.parametrize(
+    'env_var,arg,expected,call_count',
+    [
+        (None, True, True, 0),
+        (None, False, False, 0),
+        (None, None, True, 1),
+        ('', True, True, 0),
+        ('', False, False, 0),
+        ('', None, True, 1),
+        ('1', True, True, 0),
+        ('1', False, False, 0),
+        ('1', None, True, 0),
+        ('disable', True, True, 0),
+        ('disable', False, False, 0),
+        ('disable', None, False, 0),
+    ],
+)
+def test_default_force_polling_wsl(mocker, env: SetEnv, env_var, arg, expected, call_count):
+    uname = type('Uname', (), {'system': 'Linux', 'release': 'Microsoft-Standard'})
+    m = mocker.patch('platform.uname', return_value=uname())
+    if env_var is not None:
+        env('WATCHFILES_FORCE_POLLING', env_var)
+    assert _default_force_polling(arg) == expected
+    assert m.call_count == call_count

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import threading
 from contextlib import contextmanager
@@ -10,7 +9,7 @@ import anyio
 import pytest
 
 from watchfiles import Change, awatch, watch
-from watchfiles.main import _calc_async_timeout, _default_force_pulling
+from watchfiles.main import _calc_async_timeout
 
 if TYPE_CHECKING:
     from conftest import MockRustType
@@ -225,49 +224,3 @@ async def test_awatch_interrupt_raise(mocker):
     # event is set because it's set while handling the KeyboardInterrupt
     assert stop_event.is_set()
     assert count == 1
-
-
-class MockRustNotify:
-    def watch(self, *args):
-        return 'stop'
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        pass
-
-
-def test_watch_polling_not_env(mocker):
-    m = mocker.patch('watchfiles.main.RustNotify', return_value=MockRustNotify())
-
-    for _ in watch('.'):
-        pass
-
-    m.assert_called_once_with(['.'], False, False, 30, True)
-
-
-def test_watch_polling_env(mocker):
-    os.environ['WATCHFILES_FORCE_POLLING'] = '1'
-    try:
-        m = mocker.patch('watchfiles.main.RustNotify', return_value=MockRustNotify())
-
-        for _ in watch('.'):
-            pass
-
-        m.assert_called_once_with(['.'], False, True, 30, True)
-    finally:
-        del os.environ['WATCHFILES_FORCE_POLLING']
-
-
-def test_default_force_pulling():
-    try:
-        assert _default_force_pulling(True) is True
-        assert _default_force_pulling(False) is False
-        assert _default_force_pulling(None) is False
-        os.environ['WATCHFILES_FORCE_POLLING'] = '1'
-        assert _default_force_pulling(True) is True
-        assert _default_force_pulling(False) is False
-        assert _default_force_pulling(None) is True
-    finally:
-        del os.environ['WATCHFILES_FORCE_POLLING']


### PR DESCRIPTION
fix #187

To install watchfiles as per this PR:

Either:
(with rust installed)
```bash
pip install git+https://github.com/samuelcolvin/watchfiles.git@force-polling-wsl2
```

, Or if you don't have rust installed:

* download the `pypi_files` artifact from the github actions run for this PR (once CI is passing)
* extract
* `pip install pypi_files/<whichever wheel matches your system>`