### PR TITLE
Switch flake8->ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := all
 isort = isort watchfiles tests
 black = black watchfiles tests
+ruff = ruff watchfiles tests
 
 .PHONY: install
 install:
@@ -19,6 +20,7 @@ build-dev:
 
 .PHONY: format
 format:
+	$(ruff) --fix
 	$(isort)
 	$(black)
 	@echo 'max_width = 120' > .rustfmt.toml
@@ -26,7 +28,7 @@ format:
 
 .PHONY: lint-python
 lint-python:
-	flake8 --max-complexity 10 --max-line-length 120 --ignore E203,W503 watchfiles tests
+	$(ruff)
 	$(isort) --check-only --df
 	$(black) --check --diff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ force_grid_wrap = 0
 combine_as_imports = true
 color_output = true
 
+[tool.ruff]
+line-length = 120
+extend-select = ['Q']
+flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
+
 [tool.mypy]
 strict = true
 warn_return_any = false

--- a/requirements/linting.in
+++ b/requirements/linting.in
@@ -1,6 +1,5 @@
 black
-flake8
-flake8-quotes
 isort[colors]
 mypy
+ruff
 trio

--- a/requirements/linting.txt
+++ b/requirements/linting.txt
@@ -14,18 +14,10 @@ click==8.1.3
     # via black
 colorama==0.4.5
     # via isort
-flake8==5.0.4
-    # via
-    #   -r requirements/linting.in
-    #   flake8-quotes
-flake8-quotes==3.3.1
-    # via -r requirements/linting.in
 idna==3.3
     # via trio
 isort[colors]==5.10.1
     # via -r requirements/linting.in
-mccabe==0.7.0
-    # via flake8
 mypy==0.971
     # via -r requirements/linting.in
 mypy-extensions==0.4.3
@@ -38,18 +30,12 @@ pathspec==0.10.1
     # via black
 platformdirs==2.5.2
     # via black
-pycodestyle==2.9.1
-    # via flake8
-pyflakes==2.5.0
-    # via flake8
+ruff==0.0.130
+    # via -r requirements/linting.in
 sniffio==1.3.0
     # via trio
 sortedcontainers==2.4.0
     # via trio
-tomli==2.0.1
-    # via
-    #   black
-    #   mypy
 trio==0.21.0
     # via -r requirements/linting.in
 typing-extensions==4.3.0

--- a/requirements/linting.txt
+++ b/requirements/linting.txt
@@ -36,6 +36,10 @@ sniffio==1.3.0
     # via trio
 sortedcontainers==2.4.0
     # via trio
+tomli==2.0.1
+    # via
+    #   black
+    #   mypy
 trio==0.21.0
     # via -r requirements/linting.in
 typing-extensions==4.3.0


### PR DESCRIPTION
Hi @samuelcolvin ,

I noticed you moved from `flake8` to `ruff` on `pydantic-core` (https://github.com/pydantic/pydantic-core/commit/bfe2d13488edbda0101e96c73cef114999486223), so I thought it would be a good idea too in `watchfiles`.