### PR TITLE
Upgrade maturin to 0.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['maturin>=0.13,<0.14']
+requires = ['maturin>=0.14,<0.15']
 build-backend = 'maturin'
 
 [project]
@@ -53,7 +53,6 @@ Changelog = 'https://github.com/samuelcolvin/watchfiles/releases'
 
 [tool.maturin]
 bindings = 'pyo3'
-sdist-include = ['Cargo.lock']
 
 [tool.pytest.ini_options]
 testpaths = 'tests'


### PR DESCRIPTION
`Cargo.lock` is now included in sdist by default.