### PR TITLE
Build PyPy wheels for aarch64 macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
           - os: macos
             target: x86_64
             pypy: true
+          - os: macos
+            target: aarch64
+            pypy: true
           - os: windows
             ls: dir
           - os: windows


### PR DESCRIPTION
[PyPy 7.3.10](https://www.pypy.org/posts/2022/12/pypy-v7310-release.html) released with arm64 macOS support