### PR TITLE
Add --env option to pass environ

### DIFF
--- a/watchfiles/cli.py
+++ b/watchfiles/cli.py
@@ -85,6 +85,7 @@ def cli(*args_: str) -> None:
         type=str,
         help='Arguments to set on sys.argv before calling target function, used only if the target is a function',
     )
+    parser.add_argument('--env', action='store_true', help='Pass environment variables to target')
     parser.add_argument('--verbose', action='store_true', help='Set log level to "debug", wins over `--verbosity`')
     parser.add_argument(
         '--non-recursive', action='store_true', help='Do not watch for changes in sub-directories recursively'
@@ -165,6 +166,7 @@ def cli(*args_: str) -> None:
         sigint_timeout=arg_namespace.sigint_timeout,
         sigkill_timeout=arg_namespace.sigkill_timeout,
         recursive=not arg_namespace.non_recursive,
+        env=arg_namespace.env,
     )
 
 


### PR DESCRIPTION
This PR adds support to pass the environ to the target command.

This is required to ensure that certain key variables (like DYLD_LIBRARY_PATH on OSX) are passed to the target command.