### PR TITLE
pre-commit block main - related to `notify` update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,8 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.3.0
   hooks:
+  - id: no-commit-to-branch # prevent direct commits to main branch
   - id: check-yaml
     args: ['--unsafe']
   - id: check-toml


### PR DESCRIPTION
In 88465fd583314026a7a6f2e4068d8cf04d32aca4 I accidently pushed and update to the `notify` crate straight to main, avoiding that.