### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
-          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12' }}
+          args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12 3.13' }}
 
       - name: build pypy wheels
         if: ${{ matrix.pypy }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ see [the migration guide](https://watchfiles.helpmanual.io/migrating/) for more 
 
 ## Installation
 
-**watchfiles** requires Python 3.8 - 3.12.
+**watchfiles** requires Python 3.8 - 3.13.
 
 ```bash
 pip install watchfiles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Intended Audience :: Developers',
     'Intended Audience :: Information Technology',
     'Intended Audience :: System Administrators',


### PR DESCRIPTION
Helps https://github.com/samuelcolvin/watchfiles/issues/276.

Temporarily use `PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1` until PyO3 supports Python 3.13.

Hopefully there will be a PyO3 0.21.3 soon so we can remove it:

https://github.com/PyO3/pyo3/issues/4038#issuecomment-2110007551