### PR TITLE
Update mkdocstring python handler option key

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          rendering:
+          options:
             show_root_heading: true
             show_root_full_path: false
             show_source: false


### PR DESCRIPTION
Looking at the [mkdocstring global options](https://mkdocstrings.github.io/usage/#global-options) documentation, I found a little discrepancy with your `mkdocs.yml`: I suspect that using the `options` key in the python handler config may give a result closer to your wishes :)