### PR TITLE
Cargo.toml: Update PyO3 to 0.22.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.63"
 [dependencies]
 crossbeam-channel = "0.5.12"
 notify = "6.1.1"
-pyo3 = {version = "0.21.2", features = ["extension-module", "generate-import-lib"]}
+pyo3 = {version = "0.22.1", features = ["extension-module", "generate-import-lib"]}
 
 [lib]
 name = "_rust_notify"


### PR DESCRIPTION
Updates the PyO3 dependency to 0.22.1 in `Cargo.toml`. This should help with Python 3.13 compatibility.