### PR TITLE
drop PyPy 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
-          args: --release --out dist --interpreter pypy3.8 pypy3.9 pypy3.10
+          args: --release --out dist --interpreter pypy3.9 pypy3.10
 
       - run: ${{ matrix.ls || 'ls -lh' }} dist/
 


### PR DESCRIPTION
I don't want weird intermittent errors breaking CI - https://github.com/samuelcolvin/watchfiles/actions/runs/10282993215/job/28455880799