### PR TITLE
add --extensions cli arg for python filter

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,6 +56,13 @@ files:
 watchfiles --filter python 'pytest --lf' src tests
 ```
 
+If you want to watch additional file extensions beyond the default Python files (`.py`, `.pyx`, `.pyd`), you can use
+the `--extensions` flag:
+
+```bash title="Watching Python files and templates"
+watchfiles --filter python --extensions '.html,.jinja' 'pytest --lf' src tests
+```
+
 ## Help
 
 Run `watchfiles --help` for more options.

--- a/docs/cli_help.txt
+++ b/docs/cli_help.txt
@@ -1,4 +1,5 @@
 usage: watchfiles [-h] [--ignore-paths [IGNORE_PATHS]]
+                  [--extensions [EXTENSIONS]]
                   [--target-type [{command,function,auto}]]
                   [--filter [FILTER]] [--args [ARGS]] [--verbose]
                   [--non-recursive] [--verbosity [{warning,info,debug}]]
@@ -28,6 +29,8 @@ options:
   -h, --help            show this help message and exit
   --ignore-paths [IGNORE_PATHS]
                         Specify directories to ignore, to ignore multiple paths use a comma as separator, e.g. "env" or "env,node_modules"
+  --extensions [EXTENSIONS]
+                        Specify extra extensions to watch, to specify multiple extensions use a comma as separator, e.g. ".jinja" or ".html,.jinja"
   --target-type [{command,function,auto}]
                         Whether the target should be intercepted as a shell command or a python function, defaults to "auto" which infers the target type from the target string
   --filter [FILTER]     Which files to watch, defaults to "default" which uses the "DefaultFilter", "python" uses the "PythonFilter", "all" uses no filter, any other value is interpreted as a python function/class path which is imported

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,35 @@ def test_ignore_paths(mocker, tmp_work_path):
     )
 
 
+def test_extensions(mocker, tmp_work_path):
+    mocker.patch('watchfiles.cli.sys.stdin.fileno')
+    mocker.patch('os.ttyname', return_value='/path/to/tty')
+    mock_run_process = mocker.patch('watchfiles.cli.run_process')
+    cli(
+        '--extensions',
+        '.html,.jinja',
+        '--filter',
+        'python',
+        'os.getcwd',
+        '.',
+    )
+    mock_run_process.assert_called_once_with(
+        Path(str(tmp_work_path)),
+        target='os.getcwd',
+        target_type='function',
+        watch_filter=(
+            IsInstance(PythonFilter)
+            & HasAttributes(extensions=('.py', '.pyx', '.pyd', '.html', '.jinja'), _ignore_paths=())
+        ),
+        debug=False,
+        grace_period=0,
+        sigint_timeout=5,
+        sigkill_timeout=1,
+        recursive=True,
+        ignore_permission_denied=False,
+    )
+
+
 class SysError(RuntimeError):
     pass
 


### PR DESCRIPTION
This cli option is [mentioned in filters.py](https://github.com/samuelcolvin/watchfiles/blob/2b2327f2a007a32d736fffa4ab87d3f207053a49/watchfiles/filters.py#L142-L143), but not implemented. I would find it very useful to have as a CLI option rather than having to implement a custom filter just to add a couple of extensions to the python filter.