### PR TITLE
ci: add riscv64 manylinux wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,9 @@ jobs:
           - os: ubuntu
             platform: linux
             target: s390x
+          - os: ubuntu
+            platform: linux
+            target: riscv64gc-unknown-linux-gnu
           # musllinux
           - os: ubuntu
             platform: linux
@@ -208,13 +211,13 @@ jobs:
 
       - name: build sdist
         if: ${{ matrix.os == 'ubuntu' && matrix.target == 'x86_64' && matrix.manylinux == 'auto' }}
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.49.3
         with:
           command: sdist
           args: --out dist
 
       - name: build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.49.3
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
@@ -222,7 +225,7 @@ jobs:
 
       - name: build pypy wheels
         if: ${{ matrix.pypy }}
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.49.3
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}


### PR DESCRIPTION
Recent versions of maturin support riscv64, so we can now start building riscv64 wheels for watchfiles.

So add riscv64 target and upgrade maturin to the latest available version.

FYI, [RISE](https://riseproject.dev/) has been building and distributing watchfiles  manylinux wheels for riscv64 for several months (versions 1.0.5, 1.1.0 and 1.1.1). Tested builds are available for riscv64 [here](https://riseproject.gitlab.io/python/wheel_builder/packages/watchfiles.html). The gitlab pipeline to build and test watchfiles on riscv64 is available [here](https://gitlab.com/riseproject/python/wheel_builder/-/blob/main/wheel_builder/watchfiles/gitlab-ci.yml?ref_type=heads).  

As you can see we only disable `tests/test_rust_notify.py::test_ignore_permission_denied`. This test hangs because it waits for a permission denied event, but our ci script is running as the root user on GitLab runner, so we cannot trigger this permission denied event.