### PR TITLE
fix: respect false-like env flags

### DIFF
--- a/tests/test_force_polling.py
+++ b/tests/test_force_polling.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from watchfiles import watch
-from watchfiles.main import _default_force_polling
+from watchfiles.main import _default_debug, _default_force_polling
 
 if TYPE_CHECKING:
     from .conftest import SetEnv
@@ -102,3 +102,32 @@ def test_default_force_polling_wsl(mocker, env: SetEnv, env_var, arg, expected, 
         env('WATCHFILES_FORCE_POLLING', env_var)
     assert _default_force_polling(arg) == expected
     assert m.call_count == call_count
+
+
+@pytest.mark.parametrize(
+    'env_var,arg,expected',
+    [
+        (None, True, True),
+        (None, False, False),
+        (None, None, False),
+        ('', True, True),
+        ('', False, False),
+        ('', None, False),
+        ('1', True, True),
+        ('1', False, False),
+        ('1', None, True),
+        ('false', True, True),
+        ('false', False, False),
+        ('false', None, False),
+        ('disable', True, True),
+        ('disable', False, False),
+        ('disable', None, False),
+        ('disabled', True, True),
+        ('disabled', False, False),
+        ('disabled', None, False),
+    ],
+)
+def test_default_debug(env: SetEnv, env_var, arg, expected):
+    if env_var is not None:
+        env('WATCHFILES_DEBUG', env_var)
+    assert _default_debug(arg) == expected

--- a/tests/test_rust_notify.py
+++ b/tests/test_rust_notify.py
@@ -334,6 +334,15 @@ def test_ignore_permission_denied():
         ('1', True, True),
         ('1', False, False),
         ('1', None, True),
+        ('false', True, True),
+        ('false', False, False),
+        ('false', None, False),
+        ('disable', True, True),
+        ('disable', False, False),
+        ('disable', None, False),
+        ('disabled', True, True),
+        ('disabled', False, False),
+        ('disabled', None, False),
     ],
 )
 def test_default_ignore_permission_denied(env: 'SetEnv', env_var, arg, expected):

--- a/watchfiles/main.py
+++ b/watchfiles/main.py
@@ -350,8 +350,7 @@ def _default_poll_delay_ms(poll_delay_ms: int) -> int:
 def _default_debug(debug: Optional[bool]) -> bool:
     if debug is not None:
         return debug
-    env_var = os.getenv('WATCHFILES_DEBUG')
-    return bool(env_var)
+    return _default_env_var('WATCHFILES_DEBUG')
 
 
 def _auto_force_polling() -> bool:
@@ -369,5 +368,9 @@ def _auto_force_polling() -> bool:
 def _default_ignore_permission_denied(ignore_permission_denied: Optional[bool]) -> bool:
     if ignore_permission_denied is not None:
         return ignore_permission_denied
-    env_var = os.getenv('WATCHFILES_IGNORE_PERMISSION_DENIED')
-    return bool(env_var)
+    return _default_env_var('WATCHFILES_IGNORE_PERMISSION_DENIED')
+
+
+def _default_env_var(env_name: str) -> bool:
+    env_var = os.getenv(env_name)
+    return bool(env_var) and env_var.lower() not in {'false', 'disable', 'disabled'}


### PR DESCRIPTION

**Repo:** samuelcolvin/watchfiles (⭐ 2000)
**Type:** bugfix
**Files changed:** 3
**Lines:** +46/-5

## What
This change makes `WATCHFILES_DEBUG` and `WATCHFILES_IGNORE_PERMISSION_DENIED` treat explicit false-like values consistently. Instead of enabling those flags for any non-empty string, `false`, `disable`, and `disabled` now correctly resolve to `False`, and the new tests cover those cases alongside the existing truthy and unset behavior.

## Why
Before this patch, setting `WATCHFILES_DEBUG=false` or `WATCHFILES_IGNORE_PERMISSION_DENIED=false` still enabled the option because Python treated any non-empty environment variable as truthy. That is surprising for users trying to disable those flags in shell or container environments, and it was inconsistent with `WATCHFILES_FORCE_POLLING`, which already recognized false-like strings.

## Testing
Committed focused test coverage for the new env-var cases in `tests/test_force_polling.py` and `tests/test_rust_notify.py`. A direct Python sanity check confirmed the changed helper behavior for unset, empty, `1`, `false`, `disable`, and `disabled` values. Targeted pytest execution was attempted, but the host environment injects external pytest plugins that fail before repo tests run.

## Risk
Low / narrow change to env-var parsing for two boolean helpers, with matching regression coverage added.
