### PR TITLE
fix: widen awatch stop_event type to AbstractEvent (#357)

### DIFF
--- a/watchfiles/main.py
+++ b/watchfiles/main.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from enum import IntEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncGenerator, Callable, Generator, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, AsyncGenerator, Callable, Generator, Optional, Set, Tuple, Union, cast
 
 import anyio
 
@@ -155,7 +155,7 @@ async def awatch(  # C901
     watch_filter: Optional[Callable[[Change, str], bool]] = DefaultFilter(),
     debounce: int = 1_600,
     step: int = 50,
-    stop_event: Optional['AnyEvent'] = None,
+    stop_event: Optional['AbstractEvent'] = None,
     rust_timeout: Optional[int] = None,
     yield_on_timeout: bool = False,
     debug: Optional[bool] = None,
@@ -247,7 +247,7 @@ async def awatch(  # C901
     if stop_event is None:
         stop_event_: AnyEvent = anyio.Event()
     else:
-        stop_event_ = stop_event
+        stop_event_ = cast('AnyEvent', stop_event)
 
     force_polling = _default_force_polling(force_polling)
     poll_delay_ms = _default_poll_delay_ms(poll_delay_ms)


### PR DESCRIPTION
Fixes #357.

Looked into this and the reporter is right - in `awatch()`, the `stop_event` we get from the user is only ever read via `is_set()` (which actually happens over in the Rust side). We never call `.set()` on it or await it, so requiring `AnyEvent` (anyio/asyncio/trio Event) is more restrictive than it needs to be.

Switched it to `AbstractEvent`, which is the same protocol the sync `watch()` already uses. Now the two functions are consistent and folks can pass things like `threading.Event` without type-checker complaints.

The internal `stop_event_` still needs `.set()` in the cancellation handler, so I cast it back to `AnyEvent` there. No behavior change at runtime.

Side benefit: this should also help with the pyright issue where `awatch` shows up as `Unknown` for users who don't have trio installed (microsoft/pyright#5101).