### PR TITLE
Fix case-only rename on macOS APFS misclassified as two added events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,33 @@ struct RustNotify {
     watcher: WatcherEnum,
 }
 
+/// Case-sensitive check that the given path's file name exists in its parent directory.
+///
+/// `Path::exists()` resolves names through the filesystem, which is case-insensitive on
+/// the default macOS APFS and on Windows NTFS. As a result it can return `true` for a
+/// path whose exact-case filename does not exist on disk -- only a case-folded sibling
+/// does. This helper avoids that ambiguity by reading the parent directory and looking
+/// for an entry whose file name matches `path`'s file name byte-for-byte. On
+/// case-sensitive filesystems it is equivalent to `Path::exists()`.
+fn path_exists_exact_case(path: &Path) -> bool {
+    let (parent, file_name) = match (path.parent(), path.file_name()) {
+        (Some(p), Some(n)) => (p, n),
+        // Path has no parent (e.g. "/") or no file name component: fall back to exists().
+        _ => return path.exists(),
+    };
+    // An empty parent (e.g. relative bare filename like "hello.txt") means the current
+    // directory; pass it through as "." so read_dir succeeds.
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    match std::fs::read_dir(parent) {
+        Ok(entries) => entries.filter_map(|e| e.ok()).any(|e| e.file_name() == file_name),
+        Err(_) => false,
+    }
+}
+
 fn map_watch_error(error: notify::Error) -> PyErr {
     let err_string = error.to_string();
     match error.kind {
@@ -153,7 +180,14 @@ impl RustNotify {
                             // On macOS the modify name event is triggered when a file is renamed,
                             // but no information about whether it's the src or dst path is available.
                             // Hence we have to check if the file exists instead.
-                            if Path::new(&path).exists() {
+                            //
+                            // `Path::exists()` is case-insensitive on case-insensitive filesystems
+                            // (e.g. the default APFS on macOS), so for a case-only rename like
+                            // `hello.txt` -> `Hello.txt` it would report both endpoints as existing
+                            // and emit two ADDED events instead of a DELETED/ADDED pair (#368).
+                            // `path_exists_exact_case` checks the parent directory for an entry
+                            // matching `path`'s file name byte-for-byte, distinguishing the two.
+                            if path_exists_exact_case(Path::new(&path)) {
                                 CHANGE_ADDED
                             } else {
                                 CHANGE_DELETED

--- a/tests/test_files/case_rename.txt
+++ b/tests/test_files/case_rename.txt
@@ -1,0 +1,1 @@
+case rename fixture for issue #368

--- a/tests/test_rust_notify.py
+++ b/tests/test_rust_notify.py
@@ -184,6 +184,41 @@ def test_rename(test_dir: Path):
     }
 
 
+@pytest.mark.skipif(sys.platform != 'darwin', reason='macOS-specific case-insensitive APFS behaviour')
+def test_rename_case_only(test_dir: Path):
+    """Regression test for https://github.com/samuelcolvin/watchfiles/issues/368.
+
+    On the default case-insensitive APFS the rename emits two ``Modify(Name(Any))``
+    events whose paths only differ in case, both pointing at a file that ``Path::exists``
+    treats as present. Previously both events were misclassified as ADDED instead of a
+    DELETED/ADDED pair.
+    """
+    src = test_dir / 'case_rename.txt'
+    if not src.exists():
+        pytest.skip('case_rename.txt fixture missing')
+
+    # Skip if test_dir happens to live on a case-sensitive filesystem (e.g. APFS configured
+    # case-sensitive, or a UFS volume). The bug only manifests when the FS case-folds at
+    # lookup time.
+    if not (test_dir / 'CASE_RENAME.TXT').exists():
+        pytest.skip('test_dir is on a case-sensitive filesystem')
+
+    dst = test_dir / 'CASE_RENAME.txt'
+    watcher = RustNotify([str(test_dir)], False, False, 0, True, False)
+    try:
+        src.rename(dst)
+
+        assert watcher.watch(200, 50, 500, None) == {
+            (3, str(src)),
+            (1, str(dst)),
+        }
+    finally:
+        # Restore so the fixture's session-level snapshot stays consistent if this test
+        # runs before other tests that scan test_dir.
+        if dst.exists():
+            dst.rename(src)
+
+
 def test_watch_multiple(tmp_path: Path):
     foo = tmp_path / 'foo'
     foo.mkdir()


### PR DESCRIPTION
Fixes #368.

On the default case-insensitive APFS filesystem on macOS, renaming a file with only a case change — e.g. `hello.txt` → `Hello.txt` — produced two `Change.added` events instead of the expected `Change.deleted(old) + Change.added(new)` pair.

The macOS notify backend emits two `Modify(Name(Any))` events for the rename, one per path, with no source/destination hint. The fallback in `src/lib.rs` resolved this by calling `Path::exists` on the event path: the one that exists is the new path (ADDED), the one that doesn't is the old path (DELETED). On a case-insensitive filesystem `exists()` returns `true` for both `hello.txt` and `Hello.txt` (they resolve to the same inode), so both events were misclassified as ADDED.

## Repro (matches the issue)

```python
import os, tempfile, time
from pathlib import Path
from threading import Thread
from watchfiles import watch

with tempfile.TemporaryDirectory() as tmp_dir:
    watch_dir = Path(tmp_dir)
    original, renamed = watch_dir / 'hello.txt', watch_dir / 'Hello.txt'
    original.write_text('content')
    time.sleep(0.5)

    def do_rename():
        time.sleep(1.5)
        os.rename(original, renamed)
        time.sleep(3)
        (watch_dir / 'stop.txt').write_text('stop')

    Thread(target=do_rename, daemon=True).start()
    for changes in watch(watch_dir, debounce=400, step=100):
        print(changes)
        if any(Path(p).name == 'stop.txt' for _, p in changes):
            break
```

Before:
```
{(<Change.added: 1>, '.../hello.txt'), (<Change.added: 1>, '.../Hello.txt')}
```

After:
```
{(<Change.deleted: 3>, '.../hello.txt'), (<Change.added: 1>, '.../Hello.txt')}
```

## Approach

Add a small `path_exists_exact_case` helper that reads the parent directory and looks for an entry whose `OsStr` file name matches the event path's file name byte-for-byte, and use it in place of `Path::exists` for the `ModifyKind::Name(_)` branch. On case-sensitive filesystems the behaviour is unchanged (the directory entry's name matches exactly when the file exists, and `read_dir` finds nothing when it doesn't). On case-insensitive filesystems the rename's old path no longer matches any directory entry, so it is correctly classified as DELETED.

I considered using `std::fs::canonicalize` + filename comparison instead, but that follows symlinks and is happy to return an unexpected path when symlinks are in play; `read_dir` keeps the check local to the actual parent directory.

## Tests

- New `test_rename_case_only` in `tests/test_rust_notify.py` (darwin-only, with an inner skip when the FS happens to be case-sensitive) that renames `case_rename.txt` → `CASE_RENAME.txt` and asserts the DELETED/ADDED pair, then renames back so other tests are unaffected.
- New fixture file `tests/test_files/case_rename.txt`.
- The existing `test_rename` continues to pass: it renames `a.txt` → `a.new`, so both the source's exact-case entry disappears and the destination's exact-case entry appears, and both branches still resolve as before.

Verified locally on macOS 25.5 (APFS, case-insensitive): the new test fails on `main` and passes with this change. `cargo clippy -- -D warnings`, `cargo fmt --check`, `ruff check`, `ruff format --check`, and `mypy` are all clean.
