### PR TITLE
Propagate sigint_timeout/sigkill_timeout to the final process.stop() on exit

### DIFF
--- a/tests/test_run_process.py
+++ b/tests/test_run_process.py
@@ -10,7 +10,15 @@ from dirty_equals import IsStr
 
 from watchfiles import arun_process, run_process
 from watchfiles.main import Change
-from watchfiles.run import detect_target_type, import_string, run_function, set_tty, split_cmd, start_process
+from watchfiles.run import (
+    CombinedProcess,
+    detect_target_type,
+    import_string,
+    run_function,
+    set_tty,
+    split_cmd,
+    start_process,
+)
 
 if TYPE_CHECKING:
     from conftest import MockRustType
@@ -111,6 +119,19 @@ def test_sigint_timeout(mocker, mock_rust_notify: 'MockRustType', caplog):
     assert mock_spawn_process.call_count == 2
     assert mock_kill.call_count == 2
     assert "SIGINT timed out after 'sigint_timeout' seconds" in caplog.text
+
+
+def test_sigint_timeout_propagates_to_final_stop(mocker, mock_rust_notify: 'MockRustType'):
+    mocker.patch('watchfiles.run.spawn_context.Process', return_value=FakeProcess())
+    mocker.patch('watchfiles.run.os.kill')
+    stop_spy = mocker.spy(CombinedProcess, 'stop')
+    mock_rust_notify([{(1, '/path/to/foobar.py')}])
+
+    assert run_process('/x/y/z', target=object(), debounce=5, step=1, sigint_timeout=7, sigkill_timeout=8) == 1
+    # both the in-loop stop and the final stop in the finally block should use the custom timeouts
+    assert stop_spy.call_count == 2
+    for call in stop_spy.call_args_list:
+        assert call.kwargs == {'sigint_timeout': 7, 'sigkill_timeout': 8}
 
 
 def test_start_process(mocker):

--- a/watchfiles/run.py
+++ b/watchfiles/run.py
@@ -151,7 +151,7 @@ def run_process(
             process = start_process(target, target_type, args, kwargs, changes)
             reloads += 1
     finally:
-        process.stop()
+        process.stop(sigint_timeout=sigint_timeout, sigkill_timeout=sigkill_timeout)
     return reloads
 
 


### PR DESCRIPTION
`run_process()` forwards `sigint_timeout`/`sigkill_timeout` to `process.stop()` on each reload, but the final stop in the `finally` block was called with no arguments, so on exit/Ctrl+C it fell back to the default 5s/1s timeouts and ignored the values you passed in. This forwards the kwargs to that final stop too. Added a test that spies on `CombinedProcess.stop` and asserts both the in-loop and final stops use the custom timeouts (fails without the change, passes with it). Left `arun_process` alone since #258 is about sync `run_process` and it doesn't expose these params. run_process/cli tests pass locally (47 passed, 1 skipped), ruff clean.

Fixes #258