### PR TITLE
Fix test compatibility with pytest >= 9.1

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -79,7 +79,7 @@ def generate_code_chunks(*directories: str):
 # with pypy we sometimes (???) get a "The loop argument is deprecated since Python 3.8" warning, see
 # https://github.com/samuelcolvin/watchfiles/runs/7764187741
 @pytest.mark.filterwarnings('ignore:The loop argument is deprecated:DeprecationWarning')
-@pytest.mark.parametrize('module_name,source_code', generate_code_chunks('watchfiles', 'docs'))
+@pytest.mark.parametrize('module_name,source_code', list(generate_code_chunks('watchfiles', 'docs')))
 def test_docs_examples(module_name, source_code, import_execute, mocker, mock_rust_notify: 'MockRustType'):
     mock_rust_notify([{(1, 'foo.txt'), (2, 'bar.py')}])
     mocker.patch('watchfiles.run.spawn_context.Process')


### PR DESCRIPTION
pytest 9.1 no longer accepts non-Collection iterables in parametrize. Wrap the generator function call with list() in test_docs.py.

Assisted-by: Claude Opus 4.6