### PR TITLE
docs: clarify step argument wording in watch() docstring

### DIFF
--- a/watchfiles/_rust_notify.pyi
+++ b/watchfiles/_rust_notify.pyi
@@ -55,8 +55,8 @@ class RustNotify:
 
         Args:
             debounce_ms: maximum time in milliseconds to group changes over before returning.
-            step_ms: time to wait for new changes in milliseconds, if no changes are detected
-                in this time, and at least one change has been detected, the changes are yielded.
+            step_ms: interval in milliseconds between checks for new changes; once at least one change
+                has been detected, changes are yielded if no further changes are detected within this interval.
             timeout_ms: maximum time in milliseconds to wait for changes before returning,
                 `0` means wait indefinitely, `debounce_ms` takes precedence over `timeout_ms` once
                 a change is detected.

--- a/watchfiles/main.py
+++ b/watchfiles/main.py
@@ -94,8 +94,8 @@ def watch(
             or a [`BaseFilter`][watchfiles.BaseFilter] instance,
             defaults to an instance of [`DefaultFilter`][watchfiles.DefaultFilter]. To keep all changes, use `None`.
         debounce: maximum time in milliseconds to group changes over before yielding them.
-        step: time to wait for new changes in milliseconds, if no changes are detected in this time, and
-            at least one change has been detected, the changes are yielded.
+        step: interval in milliseconds between checks for new changes; once at least one change has been
+            detected, changes are yielded if no further changes are detected within this interval.
         stop_event: event to stop watching, if this is set, the generator will stop iteration,
             this can be anything with an `is_set()` method which returns a bool, e.g. `threading.Event()`.
         rust_timeout: maximum time in milliseconds to wait in the rust code for changes, `0` means no timeout.


### PR DESCRIPTION
Fixes #238

Rewords the `step` argument docstring in `watch()` to clarify the debounce behavior.