### PR TITLE
Detect same-second file edits when polling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,12 @@ impl RustNotify {
                     return Err(PyFileNotFoundError::new_err("No such file or directory"));
                 }
                 let delay = Duration::from_millis(poll_delay_ms);
-                let config = NotifyConfig::default().with_poll_interval(delay);
+                // notify::PollWatcher stores mtime as whole seconds, so same-second
+                // content edits are invisible unless we also hash file contents.
+                // See https://github.com/samuelcolvin/watchfiles/issues/319
+                let config = NotifyConfig::default()
+                    .with_poll_interval(delay)
+                    .with_compare_contents(true);
                 let mut watcher = match PollWatcher::new(event_handler, config) {
                     Ok(watcher) => watcher,
                     Err(e) => return wf_error!($msg_template, e),

--- a/tests/test_rust_notify.py
+++ b/tests/test_rust_notify.py
@@ -299,6 +299,25 @@ def test_polling(test_dir: Path):
     assert (1, str(test_dir / 'test_polling.txt')) in changes  # sometimes has an event modify too
 
 
+@skip_windows
+def test_polling_same_mtime_content_change(tmp_path: Path):
+    """Polling must see content changes even when mtime stays in the same second.
+
+    notify::PollWatcher truncates mtime to whole seconds, which is why #319 missed
+    rapid edits. compare_contents hashes the file so those edits still surface.
+    """
+    target = tmp_path / 'same_second.txt'
+    target.write_text('hello')
+    stat = target.stat()
+
+    watcher = RustNotify([str(tmp_path)], True, True, 50, True, False)
+    target.write_text('world')
+    os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+
+    changes = watcher.watch(200, 50, 800, None)
+    assert (2, str(target)) in changes
+
+
 def test_not_polling_repr(test_dir: Path):
     watcher = RustNotify([str(test_dir)], True, False, 123, True, False)
     r = repr(watcher)


### PR DESCRIPTION
Fixes #319.

`notify::PollWatcher` keeps mtime as whole seconds, so `force_polling=True` missed content changes that landed in the same second as the previous scan. Enable `compare_contents` on the poll watcher so those edits still produce a modified event.

Added a regression test that rewrites a file and then freezes its mtime, which used to be invisible to polling.