### PR TITLE
Fix ignore_paths prefix matching across path boundaries

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from pathlib import Path
@@ -71,6 +72,8 @@ def test_simple_function(mock_rust_notify: 'MockRustType'):
         (Path('x/y/z/foo.txt'), True),
         (Path.home() / 'ignore' / 'foo.txt', False),
         (Path.home() / 'ignore', False),
+        (Path.home() / 'ignore-other' / 'foo.txt', True),
+        (Path.home() / 'ignore.txt', True),
         (Path.home() / '.git' / 'foo.txt', False),
         (Path.home() / 'foo' / 'foo.txt', True),
         (Path('.git') / 'foo.txt', False),
@@ -79,6 +82,14 @@ def test_simple_function(mock_rust_notify: 'MockRustType'):
 def test_default_filter(path, expected):
     f = DefaultFilter(ignore_paths=[Path.home() / 'ignore'])
     assert f(Change.added, str(path)) == expected
+
+
+def test_ignore_path_with_trailing_separator():
+    ignored_path = Path.home() / 'ignore'
+    f = DefaultFilter(ignore_paths=[f'{ignored_path}{os.sep}'])
+
+    assert f(Change.added, str(ignored_path)) is False
+    assert f(Change.added, str(ignored_path / 'foo.txt')) is False
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='paths are different on windows')

--- a/watchfiles/filters.py
+++ b/watchfiles/filters.py
@@ -9,6 +9,15 @@ __all__ = 'BaseFilter', 'DefaultFilter', 'PythonFilter'
 logger = logging.getLogger('watchfiles.watcher')
 
 
+def _is_path_or_descendant(path: str, ignore_path: str) -> bool:
+    normalized_path = os.path.normcase(os.path.normpath(path))
+    normalized_ignore_path = os.path.normcase(os.path.normpath(ignore_path))
+    try:
+        return os.path.commonpath((normalized_path, normalized_ignore_path)) == normalized_ignore_path
+    except ValueError:
+        return False
+
+
 if TYPE_CHECKING:
     from .main import Change
 
@@ -58,7 +67,9 @@ class BaseFilter:
         entity_name = parts[-1]
         if any(r.search(entity_name) for r in self._ignore_entity_regexes):
             return False
-        elif self._ignore_paths and path.startswith(self._ignore_paths):
+        elif self._ignore_paths and any(
+            _is_path_or_descendant(path, ignore_path) for ignore_path in self._ignore_paths
+        ):
             return False
         else:
             return True


### PR DESCRIPTION
## Summary

- Match `ignore_paths` only when the changed path is the configured path or one of its descendants.
- Normalize configured and changed paths before using component-aware `commonpath` matching.
- Add regressions for sibling prefixes, filename prefixes, and configured trailing separators.

## Why

`BaseFilter` previously used raw string-prefix matching, so ignoring `/workspace/src` also ignored unrelated paths such as `/workspace/src-old/module.py` and `/workspace/src.txt`. The documented contract is to ignore full paths and their descendants.

## Testing

- `python -m pytest -q` — 110 passed, 55 skipped.
- `python -m ruff check watchfiles tests` — passed.
- `python -m ruff format --check watchfiles tests` — passed.
- `python -m py_compile watchfiles/filters.py tests/test_filters.py` — passed.
- Pristine-vs-patched regression harness: the sibling-prefix and trailing-separator cases fail before the change and pass after it.

The full Python suite was run on Windows with the published compatible native extension because Rust/Cargo is not installed locally; the temporary extension was removed and no binary is included in this PR. The source-only native build remains for CI to verify.