### PR TITLE
Don't let step outrun debounce

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,16 @@ impl RustNotify {
             _ => Some(Instant::now() + Duration::from_millis(timeout_ms)),
         };
         loop {
-            py.detach(|| sleep(step_time));
+            let sleep_for = if let Some(max_time) = max_debounce_time {
+                max_time
+                    .saturating_duration_since(Instant::now())
+                    .min(step_time)
+            } else {
+                step_time
+            };
+            if !sleep_for.is_zero() {
+                py.detach(|| sleep(sleep_for));
+            }
             match py.check_signals() {
                 Ok(_) => (),
                 Err(_) => {
@@ -309,7 +318,7 @@ impl RustNotify {
 
                 let now = Instant::now();
                 if let Some(max_time) = max_debounce_time {
-                    if now > max_time {
+                    if now >= max_time {
                         break;
                     }
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,9 +277,7 @@ impl RustNotify {
         };
         loop {
             let sleep_for = if let Some(max_time) = max_debounce_time {
-                max_time
-                    .saturating_duration_since(Instant::now())
-                    .min(step_time)
+                max_time.saturating_duration_since(Instant::now()).min(step_time)
             } else {
                 step_time
             };


### PR DESCRIPTION
The rust watch loop always slept `step` milliseconds, then maybe checked debounce. If step > debounce (the #360 repro uses step=4000, debounce=2000) the debounce deadline could never fire on time, and a quiet period was measured from the first change rather than from the last one.

Sleep the remaining debounce window when it's shorter than step, and yield once that deadline is reached.

Fixes #360